### PR TITLE
Fix CLI crashing if no plugin instance, fixes #11

### DIFF
--- a/src/webpack-chain-module-resolution-host-adapter.ts
+++ b/src/webpack-chain-module-resolution-host-adapter.ts
@@ -9,7 +9,7 @@ export class WebpackChainModuleResolutionHostAdapter extends ModuleResolutionHos
 
   constructor(host: ModuleResolutionHost, public webpackWrapper: WebpackWrapper) {
     super(host);
-    this._loader = new WebpackResourceLoader(this.webpackWrapper.compiler.createCompilation(), !!webpackWrapper.plugin.options.resourceOverride);
+    this._loader = new WebpackResourceLoader(this.webpackWrapper.compiler.createCompilation(), webpackWrapper.plugin && !!webpackWrapper.plugin.options.resourceOverride);
     webpackWrapper.externalAssetsSource = this;
   }
 


### PR DESCRIPTION
Checks if webpackWrapper.plugin exists before checking its options