### PR TITLE
Pass compiler instead of compilation to findPlugin

### DIFF
--- a/src/aot-clean-transformer/loader/text-based-loader/loader.ts
+++ b/src/aot-clean-transformer/loader/text-based-loader/loader.ts
@@ -235,7 +235,7 @@ export function aotCleanLoader(this: l.LoaderContext & { _compilation: any }, so
   if (!program) {
     try {
       const self = this;
-      const plugin = findPlugin(self._compilation);
+      const plugin = findPlugin(self._compilation.compiler);
       const options: AotCleanupLoaderOptions = loaderUtils.getOptions(this) || {};
 
       if (options.disable === false) {

--- a/src/aot-clean-transformer/loader/transformer-based-loader/loader.ts
+++ b/src/aot-clean-transformer/loader/transformer-based-loader/loader.ts
@@ -34,7 +34,7 @@ export interface AotCleanupLoaderOptions {
 }
 
 function init(this: l.LoaderContext & { _compilation: any }): void {
-  const plugin = findPlugin(this._compilation);
+  const plugin = findPlugin(this._compilation.compiler);
   const options: AotCleanupLoaderOptions = loaderUtils.getOptions(this) || {};
 
   if (options.disable === false) {

--- a/src/aot-clean-transformer/transform-walker/aot-transform-walker.ts
+++ b/src/aot-clean-transformer/transform-walker/aot-transform-walker.ts
@@ -191,6 +191,7 @@ export class AotTransformWalker extends BaseTransformWalker<AotWalkerContext> {
           undefined,
           node.modifiers,
           node.name,
+          undefined,
           node.type,
           node.initializer
         );


### PR DESCRIPTION
Otherwise causes the following error, webpack@3:
```
Module build failed: TypeError: Cannot read property 'options' of undefined
    at Object.findPlugin (node_modules/ngc-webpack/src/webpack-wrapper.js:27:20)
    at Object.aotCleanLoader (node_modules/ngc-webpack/src/aot-clean-transformer/loader/text-based-loader/loader.js:184:44)
    at Object.aotCleanLoader (node_modules/ngc-webpack/src/aot-clean-transformer/loader/index.js:15:51)
```